### PR TITLE
Fix build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 echo "Build zip"
 web-ext --overwrite-dest -s src -a target build
-cp target/moolater-2.4.zip target/moolater@codewax.xpi
+extension_version="$(node --print 'require(`./src/manifest.json`).version')"
+cp "target/moolater-$extension_version.zip" target/moolater@codewax.xpi


### PR DESCRIPTION
The build script only worked for version 2.4 of the extension. This updates the build script to fix that, by pulling the version from `manifest.json`.